### PR TITLE
store model class_name instead of model instance in the mapping

### DIFF
--- a/lib/devise/jwt/defaults_generator.rb
+++ b/lib/devise/jwt/defaults_generator.rb
@@ -44,8 +44,8 @@ module Devise
       # :reek:FeatureEnvy
       def add_mapping(inspector)
         scope = inspector.scope
-        model = inspector.model
-        defaults[:mappings][scope] = model
+        model_name = inspector.class_name
+        defaults[:mappings][scope] = model_name
       end
 
       # :reek:FeatureEnvy

--- a/lib/devise/jwt/mapping_inspector.rb
+++ b/lib/devise/jwt/mapping_inspector.rb
@@ -27,6 +27,10 @@ module Devise
         mapping.to
       end
 
+      def class_name
+        mapping.class_name
+      end
+
       def path(name)
         prefix, scope, request = path_parts(name)
         [prefix, scope, request].compact.join('/').prepend('/')


### PR DESCRIPTION
Store model name as config mappings. Helps fix the autoloading issue #22 

This should work once this PR is merged : https://github.com/waiting-for-dev/warden-jwt_auth/pull/5