### PR TITLE
Updates devise and warden-jwt_auth gems

### DIFF
--- a/devise-jwt.gemspec
+++ b/devise-jwt.gemspec
@@ -21,8 +21,8 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency 'devise', '~> 4.0'
-  spec.add_dependency 'warden-jwt_auth', '~> 0.1.2'
+  spec.add_dependency 'devise', '~> 4.3'
+  spec.add_dependency 'warden-jwt_auth', '~> 0.1.3'
 
   spec.add_development_dependency "bundler", "~> 1.12"
   spec.add_development_dependency "rake", "~> 10.0"

--- a/lib/devise/jwt/version.rb
+++ b/lib/devise/jwt/version.rb
@@ -2,6 +2,6 @@
 
 module Devise
   module JWT
-    VERSION = '0.4.1'
+    VERSION = '0.4.2'
   end
 end


### PR DESCRIPTION
Added `devise-jwt` to my Gemfile but my project depends on the latest version of `jwt` and the current version of `devise-jwt` depends on an older verions of `warden-jwt_auth` which depends on an older version of `jwt`. You get the picture.

Hopefully, this PR can get merged in to fix that. Thanks!