### PR TITLE
Add support for multiple sign_out_via methods

### DIFF
--- a/lib/devise/jwt/defaults_generator.rb
+++ b/lib/devise/jwt/defaults_generator.rb
@@ -91,16 +91,17 @@ module Devise
       def requests(inspector, name)
         path = inspector.path(name)
         methods = inspector.methods(name)
-        inspector.formats.each_with_object([]) do |format, memo|
-          methods.each do |method|
-            memo << request_for_format(path, method, format)
-          end
+        inspector.formats.each_with_object([]) do |format, requests|
+          requests.push(*requests_for_format(path, methods, format))
         end
       end
 
-      def request_for_format(path, method, format)
+      # :reek:UtilityFunction
+      def requests_for_format(path, methods, format)
         path_regexp = format ? /^#{path}.#{format}$/ : /^#{path}$/
-        [method, path_regexp]
+        methods.map do |method|
+          [method, path_regexp]
+        end
       end
     end
   end

--- a/lib/devise/jwt/defaults_generator.rb
+++ b/lib/devise/jwt/defaults_generator.rb
@@ -90,9 +90,11 @@ module Devise
       # :reek:FeatureEnvy
       def requests(inspector, name)
         path = inspector.path(name)
-        method = inspector.method(name)
-        inspector.formats.map do |format|
-          request_for_format(path, method, format)
+        methods = inspector.methods(name)
+        inspector.formats.each_with_object([]) do |format, memo|
+          methods.each do |method|
+            memo << request_for_format(path, method, format)
+          end
         end
       end
 

--- a/lib/devise/jwt/mapping_inspector.rb
+++ b/lib/devise/jwt/mapping_inspector.rb
@@ -36,15 +36,16 @@ module Devise
       end
 
       # :reek:ControlParameter
-      def method(name)
-        case name
+      def methods(name)
+        method = case name
         when :sign_in
           'POST'
         when :sign_out
-          sign_out_via.to_s.upcase
+          sign_out_via
         when :registration
           'POST'
         end
+        Array(method)
       end
 
       def formats
@@ -65,7 +66,7 @@ module Devise
       end
 
       def sign_out_via
-        mapping.sign_out_via.to_s.upcase
+        Array(mapping.sign_out_via).map(&:to_s).map(&:upcase)
       end
 
       def default_formats

--- a/lib/devise/jwt/mapping_inspector.rb
+++ b/lib/devise/jwt/mapping_inspector.rb
@@ -38,13 +38,10 @@ module Devise
       # :reek:ControlParameter
       def methods(name)
         method = case name
-        when :sign_in
-          'POST'
-        when :sign_out
-          sign_out_via
-        when :registration
-          'POST'
-        end
+                 when :sign_in      then 'POST'
+                 when :sign_out     then sign_out_via
+                 when :registration then 'POST'
+                 end
         Array(method)
       end
 
@@ -66,7 +63,9 @@ module Devise
       end
 
       def sign_out_via
-        Array(mapping.sign_out_via).map(&:to_s).map(&:upcase)
+        Array(mapping.sign_out_via).map do |method|
+          method.to_s.upcase
+        end
       end
 
       def default_formats

--- a/lib/devise/jwt/test_helpers.rb
+++ b/lib/devise/jwt/test_helpers.rb
@@ -17,7 +17,7 @@ module Devise
       # @param aud [String] The aud claim. If `nil` it will be autodetected from
       # the header name configured in `Devise::JWT.config.aud_header`.
       #
-      # :reek:LongParemeterList
+      # :reek:LongParameterList
       def self.auth_headers(headers, user, scope: nil, aud: nil)
         scope ||= Devise::Mapping.find_scope!(user)
         aud ||= headers[Warden::JWTAuth.config.aud_header]

--- a/spec/devise/jwt/defaults_generator_spec.rb
+++ b/spec/devise/jwt/defaults_generator_spec.rb
@@ -101,7 +101,9 @@ describe Devise::JWT::DefaultsGenerator do
 
     it 'respect sign_out_via configuration for destroy session requests' do
       expect(defaults[:revocation_requests]).to include(
-        ['POST', %r{^/jwt_with_blacklist_users/sign_out.json$}]
+        ['POST',   %r{^/jwt_with_blacklist_users/sign_out.json$}],
+        ['GET',    %r{^/jwt_with_whitelist_users/sign_out$}],
+        ['DELETE', %r{^/jwt_with_whitelist_users/sign_out$}]
       )
     end
 

--- a/spec/devise/jwt/mapping_inspector_spec.rb
+++ b/spec/devise/jwt/mapping_inspector_spec.rb
@@ -14,6 +14,10 @@ describe Devise::JWT::MappingInspector do
   let(:jwt_with_blacklist_inspector) do
     described_class.new(:jwt_with_blacklist_user)
   end
+  
+  let(:jwt_with_whitelist_inspector) do
+    described_class.new(:jwt_with_whitelist_user)
+  end
 
   let(:no_jwt_inspector) { described_class.new(:no_jwt_user) }
 
@@ -83,31 +87,37 @@ describe Devise::JWT::MappingInspector do
     end
   end
 
-  describe '#method' do
+  describe '#methods' do
     context 'when name is :sign_in' do
-      it "returns 'POST'" do
-        expect(jwt_with_jti_matcher_inspector.method(:sign_in)).to eq('POST')
+      it "returns ['POST']" do
+        expect(jwt_with_jti_matcher_inspector.methods(:sign_in)).to eq(['POST'])
       end
     end
 
     context 'when name is :registration' do
-      it "returns 'POST'" do
-        expect(jwt_with_jti_matcher_inspector.method(:registration)).to eq(
-          'POST'
+      it "returns ['POST']" do
+        expect(jwt_with_jti_matcher_inspector.methods(:registration)).to eq(
+          ['POST']
         )
       end
     end
 
     context 'when name is :sign_out' do
       it 'returns mapping sign_out_via option as upcased string' do
-        expect(jwt_with_jti_matcher_inspector.method(:sign_out)).to eq(
-          'DELETE'
+        expect(jwt_with_jti_matcher_inspector.methods(:sign_out)).to eq(
+          ['DELETE']
         )
       end
 
       it 'respects when sign_out_via option is not the default' do
-        expect(jwt_with_blacklist_inspector.method(:sign_out)).to eq(
-          'POST'
+        expect(jwt_with_blacklist_inspector.methods(:sign_out)).to eq(
+          ['POST']
+        )
+      end
+      
+      it 'accepts sign_out_via option when it contains multiple methods' do
+        expect(jwt_with_whitelist_inspector.methods(:sign_out)).to match_array(
+          ['GET', 'DELETE']
         )
       end
     end

--- a/spec/devise/jwt/mapping_inspector_spec.rb
+++ b/spec/devise/jwt/mapping_inspector_spec.rb
@@ -14,7 +14,7 @@ describe Devise::JWT::MappingInspector do
   let(:jwt_with_blacklist_inspector) do
     described_class.new(:jwt_with_blacklist_user)
   end
-  
+
   let(:jwt_with_whitelist_inspector) do
     described_class.new(:jwt_with_whitelist_user)
   end
@@ -114,10 +114,10 @@ describe Devise::JWT::MappingInspector do
           ['POST']
         )
       end
-      
+
       it 'accepts sign_out_via option when it contains multiple methods' do
         expect(jwt_with_whitelist_inspector.methods(:sign_out)).to match_array(
-          ['GET', 'DELETE']
+          %w[GET DELETE]
         )
       end
     end

--- a/spec/fixtures/rails_app/config/routes.rb
+++ b/spec/fixtures/rails_app/config/routes.rb
@@ -26,7 +26,8 @@ Rails.application.routes.draw do
              sign_out_via: :post
 
   devise_for :jwt_with_whitelist_users,
-             defaults: { format: :json }
+             defaults: { format: :json },
+             sign_out_via: [:get, :delete]
 
   scope 'a/scope' do
     devise_for :jwt_with_null_users,


### PR DESCRIPTION
`Devise::JWT::MappingInspector` only allowed a single `sign_out_via` method, but `devise_for` allows specification of multiple methods. When multiple methods are specified, all methods are ignored.

Added support for multiple methods and changed the name of `Devise::JWT::MappingInspector#method` to `#methods`.