### PR TITLE
Layout/EmptyLineAfterGuardClause Rubocop fix

### DIFF
--- a/lib/devise/jwt/defaults_generator.rb
+++ b/lib/devise/jwt/defaults_generator.rb
@@ -27,6 +27,7 @@ module Devise
         devise_mappings.each_key do |scope|
           inspector = MappingInspector.new(scope)
           next unless inspector.jwt?
+
           add_defaults(inspector)
         end
         defaults
@@ -62,16 +63,19 @@ module Devise
 
       def add_sign_in_request(inspector)
         return unless inspector.session?
+
         defaults[:dispatch_requests].push(*sign_in_requests(inspector))
       end
 
       def add_registration_request(inspector)
         return unless inspector.registration?
+
         defaults[:dispatch_requests].push(*registration_requests(inspector))
       end
 
       def add_revocation_requests(inspector)
         return unless inspector.session?
+
         defaults[:revocation_requests].push(*sign_out_requests(inspector))
       end
 


### PR DESCRIPTION
Little fix for rubocop 0.60.0.

[Link to docs](https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Layout/EmptyLineAfterGuardClause)

```bash
rubocop -a lib/devise/jwt/defaults_generator.rb
Inspecting 1 file
C

Offenses:

lib/devise/jwt/defaults_generator.rb:29:11: C: [Corrected] Layout/EmptyLineAfterGuardClause: Add empty line after guard clause.
          next unless inspector.jwt?
          ^^^^^^^^^^^^^^^^^^^^^^^^^^
lib/devise/jwt/defaults_generator.rb:64:9: C: [Corrected] Layout/EmptyLineAfterGuardClause: Add empty line after guard clause.
        return unless inspector.session?
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
lib/devise/jwt/defaults_generator.rb:69:9: C: [Corrected] Layout/EmptyLineAfterGuardClause: Add empty line after guard clause.
        return unless inspector.registration?
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
lib/devise/jwt/defaults_generator.rb:74:9: C: [Corrected] Layout/EmptyLineAfterGuardClause: Add empty line after guard clause.
        return unless inspector.session?
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

1 file inspected, 4 offenses detected, 4 offenses corrected
```