### PR TITLE
Bump recommended gem version

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ You can read about which security concerns this library takes into account and a
 Add this line to your application's Gemfile:
 
 ```ruby
-gem 'devise-jwt', '~> 0.5.9'
+gem 'devise-jwt', '~> 0.6.0'
 ```
 
 And then execute:


### PR DESCRIPTION
I had no end of troubles with 0.5.9.  0.6.0 seems to fix them all, but it wasn't obvious from the README.