### PR TITLE
Update README with correct implementation of jwt_payload

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,11 +80,12 @@ class User < ApplicationRecord
 end
 ```
 
-If you need to add something to the JWT payload, you can do it defining a `jwt_payload` method in the user model. It must return a `Hash`. For instance:
+If you need to add something to the JWT payload, you can do it defining a `jwt_payload` method in the user model.
+It must return a `Hash` and be merged into the original one, or else it will be overriden. For instance:
 
 ```ruby
 def jwt_payload
-  { 'foo' => 'bar' }
+  super.merge({ 'foo' => 'bar' })
 end
 ```
 


### PR DESCRIPTION
According to the README, we should just override the `jwt_payload` method and return a `Hash`, and the parameters would be there in the payload. This is incorrect and might lead to problems.

The correct README should state that the original hash needs to be merged together with the hash you want to add.