### PR TITLE
fix setting Dry-configurable 0.11

### DIFF
--- a/devise-jwt.gemspec
+++ b/devise-jwt.gemspec
@@ -22,17 +22,17 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency 'devise', '~> 4.0'
-  spec.add_dependency 'warden-jwt_auth', '~> 0.4'
+  spec.add_dependency 'warden-jwt_auth', '~> 0.5'
 
   spec.add_development_dependency "bundler", "> 1"
-  spec.add_development_dependency "rake", "~> 12.3"
-  spec.add_development_dependency "rspec", "~> 3.8"
+  spec.add_development_dependency "rake", "~> 13.0"
+  spec.add_development_dependency "rspec"
   spec.add_development_dependency "pry-byebug", "~> 3.7"
   # Needed to test the rails fixture application
-  spec.add_development_dependency 'rails', '~> 5.0'
+  spec.add_development_dependency 'rails', '~> 6.0'
   spec.add_development_dependency 'sqlite3', '~> 1.3'
-  spec.add_development_dependency 'rspec-rails', '~> 3.5'
+  spec.add_development_dependency 'rspec-rails', '~> 4.0'
   # Test reporting
-  spec.add_development_dependency 'simplecov', '0.17'
-  spec.add_development_dependency 'codeclimate-test-reporter', '~> 1.0'
+  spec.add_development_dependency 'simplecov'
+  spec.add_development_dependency 'codeclimate-test-reporter'
 end

--- a/lib/devise/jwt.rb
+++ b/lib/devise/jwt.rb
@@ -28,23 +28,31 @@ module Devise
   module JWT
     extend Dry::Configurable
 
-    setting(:secret) do |value|
+    def forward_to_warden(setting, value)
+      default = Warden::JWTAuth.config.send("#{setting}")
+      Warden::JWTAuth.config.send("#{setting}=", value || default)
+      Warden::JWTAuth.config.send("#{setting}")
+    end
+
+    module_function :forward_to_warden
+
+    setting(:secret, Warden::JWTAuth.config.secret) do |value|
       forward_to_warden(:secret, value)
     end
 
-    setting(:expiration_time) do |value|
+    setting(:expiration_time, Warden::JWTAuth.config.expiration_time ) do |value|
       forward_to_warden(:expiration_time, value)
     end
 
-    setting(:dispatch_requests) do |value|
+    setting(:dispatch_requests, Warden::JWTAuth.config.dispatch_requests) do |value|
       forward_to_warden(:dispatch_requests, value)
     end
 
-    setting(:revocation_requests) do |value|
+    setting(:revocation_requests, Warden::JWTAuth.config.revocation_requests) do |value|
       forward_to_warden(:revocation_requests, value)
     end
 
-    setting(:aud_header) do |value|
+    setting(:aud_header, Warden::JWTAuth.config.aud_header) do |value|
       forward_to_warden(:aud_header, value)
     end
 
@@ -62,9 +70,5 @@ module Devise
     #   admin_user: [nil, :xml]
     # }
     setting :request_formats, {}
-
-    def self.forward_to_warden(setting, value)
-      Warden::JWTAuth.config.send("#{setting}=", value)
-    end
   end
 end

--- a/lib/devise/jwt.rb
+++ b/lib/devise/jwt.rb
@@ -17,7 +17,9 @@ module Devise
   #
   # @see Warden::JWTAuth
   def self.jwt
+    Warden::JWTAuth.config.to_h
     yield(Devise::JWT.config)
+    Devise::JWT.config.to_h
   end
 
   add_module(:jwt_authenticatable, strategy: :jwt)

--- a/lib/devise/jwt/version.rb
+++ b/lib/devise/jwt/version.rb
@@ -2,6 +2,6 @@
 
 module Devise
   module JWT
-    VERSION = '0.7.0'
+    VERSION = '0.8.0'
   end
 end


### PR DESCRIPTION
@waiting-for-dev
Thank you for your work on this gem.

I fixed the issue in #172 
https://github.com/waiting-for-dev/warden-jwt_auth/issues/22
https://github.com/waiting-for-dev/warden-jwt_auth/issues/21
https://github.com/waiting-for-dev/warden-jwt_auth/issues/27

I also set the default values from Warden::JWTAuth.config.

This fix is backward compatible.
You just have to release a new version of warden-jwt_auth with ~> 0.9 in dry-configurable.

