### PR TITLE
Change config initializer to support autoloading

### DIFF
--- a/lib/devise/jwt/railtie.rb
+++ b/lib/devise/jwt/railtie.rb
@@ -9,7 +9,7 @@ module Devise
       initializer 'devise-jwt-middleware' do |app|
         app.middleware.use Warden::JWTAuth::Middleware
 
-        config.after_initialize do
+        ActiveSupport::Reloader.to_prepare do
           Rails.application.reload_routes!
 
           Warden::JWTAuth.configure do |config|

--- a/lib/devise/jwt/railtie.rb
+++ b/lib/devise/jwt/railtie.rb
@@ -9,7 +9,15 @@ module Devise
       initializer 'devise-jwt-middleware' do |app|
         app.middleware.use Warden::JWTAuth::Middleware
 
-        ActiveSupport::Reloader.to_prepare do
+        config.to_prepare do
+          Warden::JWTAuth.configure do |config|
+            defaults = DefaultsGenerator.call
+
+            config.mappings = defaults[:mappings]
+          end
+        end
+
+        config.after_initialize do
           Rails.application.reload_routes!
 
           Warden::JWTAuth.configure do |config|

--- a/lib/devise/jwt/railtie.rb
+++ b/lib/devise/jwt/railtie.rb
@@ -9,7 +9,7 @@ module Devise
       initializer 'devise-jwt-middleware' do |app|
         app.middleware.use Warden::JWTAuth::Middleware
 
-        config.to_prepare do
+        ActiveSupport::Reloader.to_prepare do
           Warden::JWTAuth.configure do |config|
             defaults = DefaultsGenerator.call
 


### PR DESCRIPTION
Continuing from issue #183, i found out the root of the problem. 
config.after_initialize would run only once after the app was initialized. 

So, if you changed any code, user_repo would be outdated and throw a mapping error. 
Using `ActiveSupport::Reloader.to_prepare` to set configurations will set the new user_repo after each reload and solve the mapping problem

As i did not dig into other methods in devise-jwt and warden-jwt i don't know how it will impact in the following lines
`#19 config.dispatch_requests.push(*defaults[:dispatch_requests])`
`#20 config.revocation_requests.push(*defaults[:revocation_requests])`
`#21 config.revocation_strategies = defaults[:revocation_strategies]`

So, if needed, i can isolate `config.mappings = defaults[:mappings]` to reload and lines 19, 20 and 21 so only `config.mappings = defaults[:mappings]` gets oupdated on reload.