### PR TITLE
Allow JWT key configuration.

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,14 @@ class User < ApplicationRecord
 end
 ```
 
+To use an alternative key for your JWT subject, override `jwt_subject_key` to return a symbol for the accessor to call. e.g.
+
+```ruby
+def self.jwt_subject_key
+  :uuid
+end
+```
+
 If you need to add something to the JWT payload, you can do it defining a `jwt_payload` method in the user model. It must return a `Hash`. For instance:
 
 ```ruby

--- a/lib/devise/jwt/models/jwt_authenticatable.rb
+++ b/lib/devise/jwt/models/jwt_authenticatable.rb
@@ -17,12 +17,16 @@ module Devise
 
       included do
         def self.find_for_jwt_authentication(sub)
-          find_by(primary_key => sub)
+          find_by(jwt_subject_key => sub)
+        end
+
+        def self.jwt_subject_key
+          primary_key
         end
       end
 
       def jwt_subject
-        id
+        send(self.jwt_subject_key)
       end
     end
   end


### PR DESCRIPTION
Introduces a new method to define what key should be included into the JWT as a subject. This enables using secondary keys to keep primary keys private to their services.