### PR TITLE
FIX: "No verification key available" on token decode

### DIFF
--- a/lib/devise/jwt.rb
+++ b/lib/devise/jwt.rb
@@ -17,9 +17,7 @@ module Devise
   #
   # @see Warden::JWTAuth
   def self.jwt
-    Warden::JWTAuth.config.to_h
     yield(Devise::JWT.config)
-    Devise::JWT.config.to_h
   end
 
   add_module(:jwt_authenticatable, strategy: :jwt)


### PR DESCRIPTION
`Warden::JWTAuth` shipped a feature for Asymmetric algorithms which adds a configuration setting for `decoding_secret`. By default, this is setting is configured to use `secret` when it is not otherwise explicitly set.

On first encounter and my limited testing, I thought the default behavior was not correctly working and submitted an issue on: https://github.com/waiting-for-dev/warden-jwt_auth/issues/44

Upon further testing, however, it was clear the defaults were working as expected in that repository. The issue turned out to be that the configuration was being prematurely "cached" as nil before `secret` was ever set in devise-jwt.

Before:

Output of Devise::JWT.config
```
{
  secret: "keep-it-secret",
  ...
}
```

Output of Warden::JWTAuth.config
```
{
  secret: "keep-it-secret",
  decoding_secret: nil,
  ...
}
```

After:

Output of Devise::JWT.config
```
{
  secret: "keep-it-secret",
  ...
}
```

Output of Warden::JWTAuth.config
```
{
  secret: "keep-it-secret",
  decoding_secret: "keep-it-secret",
  ...
}
```

I'm not entirely sure the purpose the `.to_h` was serving in `self.jwt`; however, all of the specs still pass without those lines, the configuration looks correct / yielding the expected settings, and testing against the app that prompted this deep dive is resolved with this change.