### PR TITLE
Enable asymmetric algorithms

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ For `Denylist`, you only need to update the `include` line you're using in your 
 
 ```ruby
 # include Devise::JWT::RevocationStrategies::Blacklist # before
-include Devise::JWT::RevocationStrategies::Denylist 
+include Devise::JWT::RevocationStrategies::Denylist
 ```
 
 For `Allowlist`, you need to update the `include` line you're using in your user model:
@@ -78,9 +78,9 @@ end
 
 If you are using Encrypted Credentials (Rails 5.2+), you can store the secret key in `config/credentials.yml.enc`.
 
-Open your credentials editor using `bin/rails credentials:edit` and add `devise_jwt_secret_key`. 
+Open your credentials editor using `bin/rails credentials:edit` and add `devise_jwt_secret_key`.
 
-**Note** you may need to set `$EDITOR` depending on your specific environment.
+> **Note** you may need to set `$EDITOR` depending on your specific environment.
 
 ```yml
 
@@ -101,9 +101,32 @@ Devise.setup do |config|
 end
 ```
 
-**Important:** You are encouraged to use a secret different than your application `secret_key_base`. It is quite possible that some other component of your system is already using it. If several components share the same secret key, chances that a vulnerability in one of them has a wider impact increase. In rails, generating new secrets is as easy as `bundle exec rake secret`. Also, never share your secrets pushing it to a remote repository, you are better off using an environment variable like in the example.
+> **Important:** You are encouraged to use a secret different than your application `secret_key_base`. It is quite possible that some other component of your system is already using it. If several components share the same secret key, chances that a vulnerability in one of them has a wider impact increase. In rails, generating new secrets is as easy as `bundle exec rake secret`. Also, never share your secrets pushing it to a remote repository, you are better off using an environment variable like in the example.
 
-Currently, HS256 algorithm is the one in use.
+Currently, HS256 algorithm is the one in use. You may configure a matching secret and algorithm name to use a different one (see [ruby-jwt](https://github.com/jwt/ruby-jwt#algorithms-and-usage) to see which are supported):
+
+```ruby
+Devise.setup do |config|
+  # ...
+  config.jwt do |jwt|
+    jwt.secret = OpenSSL::PKey::RSA.new(Rails.application.credentials.devise_jwt_secret_key!)
+    jwt.algorithm = Rails.application.credentials.devise_jwt_algorithm!
+  end
+end
+```
+
+If the algorithm is asymmetric (e.g. RS256) which necessitates a different decoding secret, configure the `decoding_secret` setting as well:
+
+```ruby
+Devise.setup do |config|
+  # ...
+  config.jwt do |jwt|
+    jwt.secret = OpenSSL::PKey::RSA.new(Rails.application.credentials.devise_jwt_private_key!)
+    jwt.decoding_secret = OpenSSL::PKey::RSA.new(Rails.application.credentials.devise_jwt_public_key!)
+    jwt.algorithm = 'RS256' # or some other asymmetric algorithm
+  end
+end
+```
 
 ### Model configuration
 

--- a/lib/devise/jwt.rb
+++ b/lib/devise/jwt.rb
@@ -17,9 +17,7 @@ module Devise
   #
   # @see Warden::JWTAuth
   def self.jwt
-    Warden::JWTAuth.config.to_h
     yield(Devise::JWT.config)
-    Devise::JWT.config.to_h
   end
 
   add_module(:jwt_authenticatable, strategy: :jwt)

--- a/lib/devise/jwt.rb
+++ b/lib/devise/jwt.rb
@@ -36,6 +36,12 @@ module Devise
             default: Warden::JWTAuth.config.secret,
             constructor: ->(value) { forward_to_warden(:secret, value) })
 
+    setting(:decoding_secret,
+            constructor: ->(value) { forward_to_warden(:decoding_secret, value) })
+
+    setting(:algorithm,
+            constructor: ->(value) { forward_to_warden(:algorithm, value) })
+
     setting(:expiration_time,
             default: Warden::JWTAuth.config.expiration_time,
             constructor: ->(value) { forward_to_warden(:expiration_time, value) })


### PR DESCRIPTION
## Description

`Warden::JWTAuth` added support for asymmetric algorithms, allowing the
specification of a separate decoding secret from the standard secret.

This, along with the (included) change from #250, fixes the "No verification key
available" error as well as enables support to allow folks to use `Devise::JWT` with an algorithm of their choosing, including an asymmetric algorithm if they so choose.