### PR TITLE
Add support for rotation_secret

### DIFF
--- a/README.md
+++ b/README.md
@@ -481,6 +481,10 @@ end
 
 Secret key is used to sign generated JWT tokens. You must set it.
 
+#### rotation_secret
+
+Allow rotating secrets. Set a new value to `secret` and copy the old secret to `rotation_secret`.
+
 #### expiration_time
 
 Number of seconds while a JWT is valid after its generation. After that, it won't be valid anymore, even if it hasn't been revoked.

--- a/devise-jwt.gemspec
+++ b/devise-jwt.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency 'devise', '~> 4.0'
-  spec.add_dependency 'warden-jwt_auth', '~> 0.6'
+  spec.add_dependency 'warden-jwt_auth', '~> 0.8'
 
   spec.add_development_dependency "bundler", "> 1"
   spec.add_development_dependency "rake", "~> 13.0"

--- a/lib/devise/jwt.rb
+++ b/lib/devise/jwt.rb
@@ -36,6 +36,10 @@ module Devise
             default: Warden::JWTAuth.config.secret,
             constructor: ->(value) { forward_to_warden(:secret, value) })
 
+    setting(:rotation_secret,
+            default: Warden::JWTAuth.config.rotation_secret,
+            constructor: ->(value) { forward_to_warden(:rotation_secret, value) })
+
     setting(:decoding_secret,
             constructor: ->(value) { forward_to_warden(:decoding_secret, value) })
 


### PR DESCRIPTION
## Summary

Workss in conjunction with https://github.com/waiting-for-dev/warden-jwt_auth/pull/49/files. 

Allows rotating secret. The PR does not include any functionality other than exposing the `rotation_secret` configuration variable from [warden-jwt_auth](https://github.com/waiting-for-dev/warden-jwt_auth).

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [X] I have written a thorough PR description.
- [X] I have kept my commits small and atomic.
- [X] I have used clear, explanatory commit messages.

The following are not always needed (~cross them out~ if they are not):

~- [ ] I have added automated tests to cover my changes.~
~- [ ] I have attached screenshots to demo visual changes.~
~- [ ] I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).~
- [X] I have updated the README to account for my changes.
