### PR TITLE
Adds Ruby 3.2 to the CI matrix.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ['2.7', '3.0', '3.1', ruby-head]
+        ruby-version: ['2.7', '3.0', '3.1', '3.2', ruby-head]
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
## Summary

Adds Ruby 3.2 to the CI matrix to ensure that this gem can be used in Ruby 3.2 applications.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [X] I have written a thorough PR description.
- [X] I have kept my commits small and atomic.
- [X] I have used clear, explanatory commit messages.

