### PR TITLE
Add Ruby 3.3 to CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ['3.0', '3.1', '3.2', ruby-head]
+        ruby-version: ['3.0', '3.1', '3.2', '3.3', ruby-head]
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

Adds Ruby 3.3 to the CI matrix.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] I have used clear, explanatory commit messages.

