### PR TITLE
chore(docs): rake secret was deprecated, do rails secret

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Devise.setup do |config|
 end
 ```
 
-> **Important:** You are encouraged to use a secret different than your application `secret_key_base`. It is quite possible that some other component of your system is already using it. If several components share the same secret key, chances that a vulnerability in one of them has a wider impact increase. In rails, generating new secrets is as easy as `bundle exec rake secret`. Also, never share your secrets pushing it to a remote repository, you are better off using an environment variable like in the example.
+> **Important:** You are encouraged to use a secret different than your application `secret_key_base`. It is quite possible that some other component of your system is already using it. If several components share the same secret key, chances that a vulnerability in one of them has a wider impact increase. In rails, generating new secrets is as easy as `rails secret`. Also, never share your secrets pushing it to a remote repository, you are better off using an environment variable like in the example.
 
 Currently, HS256 algorithm is the one in use. You may configure a matching secret and algorithm name to use a different one (see [ruby-jwt](https://github.com/jwt/ruby-jwt#algorithms-and-usage) to see which are supported):
 


### PR DESCRIPTION

## Summary

Minor fix of the README. When running recommended command to create a secret I ran into an error.
```bash
❯ bundle exec rake secret           
rake aborted!
Don't know how to build task 'secret' (See the list of available tasks with `rake --tasks`)
/home/thaymonkey/.rbenv/versions/3.1.2/bin/bundle:25:in `load'
/home/thaymonkey/.rbenv/versions/3.1.2/bin/bundle:25:in `<main>'
(See full trace by running task with --trace)
```
Seems like in the last rails versions `secret` was moved from rake to rails. See this post in Stack Overflow for more info https://stackoverflow.com/questions/77855137/dont-know-how-to-build-task-secret

## Checklist

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] I have used clear, explanatory commit messages.

The following are not always needed (~cross them out~ if they are not):

- [ ] I have added automated tests to cover my changes.
- [ ] I have attached screenshots to demo visual changes.
- [x] I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- [ ] I have updated the README to account for my changes.
