### PR TITLE
Add support for configurable token header

### DIFF
--- a/README.md
+++ b/README.md
@@ -571,6 +571,12 @@ jwt.request_formats = {
 
 By default, only requests without format are processed.
 
+#### token_header
+
+Request/response header which will transmit the JWT token. Make sure you configure this header as described in [Model configuration](#model-configuration)
+
+Defaults to 'Authorization'
+
 #### aud_header
 
 Request header which content will be stored to the `aud` claim in the payload.

--- a/lib/devise/jwt.rb
+++ b/lib/devise/jwt.rb
@@ -54,6 +54,10 @@ module Devise
             default: Warden::JWTAuth.config.revocation_requests,
             constructor: ->(value) { forward_to_warden(:revocation_requests, value) })
 
+    setting(:token_header,
+            default: Warden::JWTAuth.config.token_header,
+            constructor: ->(value) { forward_to_warden(:token_header, value) })
+
     setting(:aud_header,
             default: Warden::JWTAuth.config.aud_header,
             constructor: ->(value) { forward_to_warden(:aud_header, value) })


### PR DESCRIPTION
## Summary

Adds the ability to configure the header is passed to `warden-jwt_auth` which is used to sent/receive the JWT token. This has been used in a production environment for more than 1 year, and the corresponding change has been merged to `warden-jwt_auth` in [this PR](https://github.com/waiting-for-dev/warden-jwt_auth/pull/55)

**Why it was needed**
When implementing devise-jwt to my platform, an issue was encountered with the 'Authorization' header always being used to transmit the JWT token. This is due to testing environments that use basic HTTP authentication, in which the 'Authorization' header is used for this authentication.
This update allowed us to use a different header in our testing environments to avoid conflicting.

**How it works**
If you need a custom header for a reason like the above, set the token_header configuration option. If you do not set an option, it will default to 'Authorization' in warden and so will not affect existing implementations.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] I have used clear, explanatory commit messages.

The following are not always needed (~cross them out~ if they are not):

~- [ ] I have added automated tests to cover my changes.~
~- [ ] I have attached screenshots to demo visual changes.~
~- [ ] I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).~
- [x] I have updated the README to account for my changes.
