### PR TITLE
Update devise-jwt.gemspec to make it compatible with devise 5 alpha

### DIFF
--- a/devise-jwt.gemspec
+++ b/devise-jwt.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency 'devise', '~> 4.0'
+  spec.add_dependency 'devise', '>= 4.0'
   spec.add_dependency 'warden-jwt_auth', '~> 0.10'
 
   spec.add_development_dependency "bundler", "> 1"


### PR DESCRIPTION
## Summary
Devise started the development of devise 5 in its alpha phase. I believe it's safe to have a less strict on the dependency's version

This is also so that people using devise's main branch can still use `devise-jwt` 

<!--
  Please include a summary of your changes, along with any useful context.

  You're encouraged to include screenshots in case of visual changes.

  If needed, you can reference other PRs or issues here with #ISSUE-NUMBER.
  You can use GitHub-specific syntax, e.g.

  Fixes #ISSUE-NUMBER

  However, if yuou do not have merge permissions on the repo, issues won't be auto-closed.
-->

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] I have used clear, explanatory commit messages.

