### PR TITLE
Use optimized loading of default configuration for test / development environments

### DIFF
--- a/devise-jwt.gemspec
+++ b/devise-jwt.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency 'devise', '~> 4.0'
+  spec.add_dependency 'devise', '>= 4.0'
   spec.add_dependency 'warden-jwt_auth', '~> 0.10'
 
   spec.add_development_dependency "bundler", "> 1"

--- a/lib/devise/jwt/railtie.rb
+++ b/lib/devise/jwt/railtie.rb
@@ -9,24 +9,13 @@ module Devise
       initializer 'devise-jwt-middleware' do |app|
         app.middleware.use Warden::JWTAuth::Middleware
 
-        config.after_initialize do
-          Rails.application.reload_routes!
-
+        config.after_routes_loaded do
           Warden::JWTAuth.configure do |config|
             defaults = DefaultsGenerator.call
 
             config.mappings = defaults[:mappings]
             config.dispatch_requests.push(*defaults[:dispatch_requests])
             config.revocation_requests.push(*defaults[:revocation_requests])
-            config.revocation_strategies = defaults[:revocation_strategies]
-          end
-        end
-
-        ActiveSupport::Reloader.to_prepare do
-          Warden::JWTAuth.configure do |config|
-            defaults = DefaultsGenerator.call
-
-            config.mappings = defaults[:mappings]
             config.revocation_strategies = defaults[:revocation_strategies]
           end
         end

--- a/spec/fixtures/rails_app/Gemfile
+++ b/spec/fixtures/rails_app/Gemfile
@@ -10,6 +10,8 @@ gem 'rails'
 gem 'sqlite3'
 # Use Puma as the app server
 gem 'puma'
+
+gem 'devise', github: 'heartcombo/devise', branch: 'main'
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
 # gem 'jbuilder', '~> 2.5'
 # Use ActiveModel has_secure_password

--- a/spec/fixtures/rails_app/Gemfile.lock
+++ b/spec/fixtures/rails_app/Gemfile.lock
@@ -1,8 +1,20 @@
+GIT
+  remote: https://github.com/heartcombo/devise.git
+  revision: fec67f98f26fcd9a79072e4581b1bd40d0c7fa1d
+  branch: main
+  specs:
+    devise (5.0.0.beta)
+      bcrypt (~> 3.0)
+      orm_adapter (~> 0.1)
+      railties (>= 6.0.0)
+      responders
+      warden (~> 1.2.3)
+
 PATH
   remote: ../../..
   specs:
     devise-jwt (0.12.1)
-      devise (~> 4.0)
+      devise (>= 4.0)
       warden-jwt_auth (~> 0.10)
 
 GEM
@@ -85,15 +97,9 @@ GEM
     bigdecimal (3.1.9)
     builder (3.3.0)
     concurrent-ruby (1.3.5)
-    connection_pool (2.5.1)
+    connection_pool (2.5.3)
     crass (1.0.6)
     date (3.4.1)
-    devise (4.9.4)
-      bcrypt (~> 3.0)
-      orm_adapter (~> 0.1)
-      railties (>= 4.1.0)
-      responders
-      warden (~> 1.2.3)
     drb (2.2.1)
     dry-auto_inject (1.1.0)
       dry-core (~> 1.1)
@@ -147,14 +153,14 @@ GEM
     pp (0.6.2)
       prettyprint
     prettyprint (0.2.0)
-    psych (5.2.3)
+    psych (5.2.5)
       date
       stringio
     puma (6.6.0)
       nio4r (~> 2.0)
     racc (1.8.1)
-    rack (3.1.13)
-    rack-session (2.1.0)
+    rack (3.1.14)
+    rack-session (2.1.1)
       base64 (>= 0.1.0)
       rack (>= 3.0.0)
     rack-test (2.2.0)
@@ -225,6 +231,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  devise!
   devise-jwt!
   puma
   rails

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -30,4 +30,10 @@ end
 
 RSpec.configure do |config|
   config.use_transactional_fixtures = true
+
+  # Make sure routes are loaded once before the test suite is run
+  # Since they are lazy loaded by default on Rails 8
+  config.before(:suite) do
+    Rails.application.try(:reload_routes_unless_loaded)
+  end
 end


### PR DESCRIPTION
## Context
While investigating our big production rails application in development/test mode, i've realized that rails routes file was loaded on startup as well as all our devise models. It was thanks to this script in this [conference](https://www.youtube.com/watch?v=9-PWz9nbrT8&t=1487s&ab_channel=EvilMartians).

the flow is the following : 
1- `gem 'devise-jwt'` in `Gemfile`
2- this registers a Railties that loads routes at initialization
3- then run a rails command such as `bin/rails console` or `bin/rails server` that triggers the rails initializaiton process
4- the hook registered by `devise-jwt` is run at startup
5- all routes are loaded even for `rails runner` or `rails console` or `rails test` ( for unit tests that don't need routes to be loaded )

this can speedup both development and test environement especially for big applications that have a lot of routes. and avoids loading ActiveRecord on startup when/if not needed
## Solution

Rails recently added a hook called [`after_routes_loaded`](https://github.com/rails/rails/blob/747f85f200e7bb2c1a31b4e26e5a5655e2dc0cdc/railties/lib/rails/railtie/configuration.rb#L75-L77) that triggers as the name suggests when the routes are loaded, and since devise-jwt needs the routes to be loaded in order to register the defaults for all devise models, this is I believe the perfect compromise for all environments ( test/dev and production )

cc @waiting-for-dev 