### PR TITLE
Allow `devise-jwt` to be used with `devise` `5.0.0.rc`

### DIFF
--- a/devise-jwt.gemspec
+++ b/devise-jwt.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency 'devise', '~> 4.0'
+  spec.add_dependency 'devise', '>= 4.0.0', '< 6.0.0'
   spec.add_dependency 'warden-jwt_auth', '~> 0.10'
 
   spec.add_development_dependency "bundler", "> 1"

--- a/spec/fixtures/rails_app/Gemfile.lock
+++ b/spec/fixtures/rails_app/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ../../..
   specs:
     devise-jwt (0.12.1)
-      devise (~> 4.0)
+      devise (>= 4.0.0, < 6.0.0)
       warden-jwt_auth (~> 0.10)
 
 GEM
@@ -88,10 +88,10 @@ GEM
     connection_pool (2.5.1)
     crass (1.0.6)
     date (3.4.1)
-    devise (4.9.4)
+    devise (5.0.0.rc)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
-      railties (>= 4.1.0)
+      railties (>= 7.0)
       responders
       warden (~> 1.2.3)
     drb (2.2.1)


### PR DESCRIPTION
This updates the `devise` dependency to allow installation with `5.0.0.rc`. This addresses #290 and is more constrained than #275 (which would allow a future v6, v7 and so on).

With this change, the existing `devise-jwt` unit tests are passing with the updated version of `devise`; reviewing https://github.com/heartcombo/devise/blob/main/CHANGELOG.md#500rc---2025-12-31, it doesn't appear that any of its breaking changes affect `devise-jwt`. 

There is the potential for other breaking changes to be introduced in a future `5.0.0` final release, though the same could be said of any hypothetically buggy `5.0.1` or above. If this is a concern, the version restriction could temporarily become `'>= 4.0.0', '<= 5.0.0.rc'`.